### PR TITLE
Compressão de imagens

### DIFF
--- a/main_app/views.py
+++ b/main_app/views.py
@@ -675,8 +675,6 @@ def edit_profile(request, username):
 						im.thumbnail(max_size)
 						im.save('django_project/media/avatars/' + file_name)
 				except UnidentifiedImageError:
-					import traceback
-					traceback.print_exc()
 					return redirect('/user/' + request.user.username + '/edit')  # TODO: Mostrar um erro de arquivo invalido!
 
 				u = UserProfile.objects.get(user=request.user)


### PR DESCRIPTION
O Asker precisa comprimir as imagens - tanto p/ deixar o carregamento das páginas mais rápidas quanto p/ aliviar espaço no servidor... coloquei a compressão p/ avatares pra dar uma testada. Ainda não funciona p/ gifs e webps pois quando são animados o pillow só salva o primeiro frame, então tem q fazer uma função específica pra eles.

OBS.: acho que seria uma boa comprimir as imagens já upadas também, tem umas enormes lá