### PR TITLE
Dark mode automático desativado

### DIFF
--- a/main_app/templates/index.html
+++ b/main_app/templates/index.html
@@ -140,9 +140,6 @@
 if (getDarkCookie() == 'true') {
 	document.getElementsByClassName('navbar')[0].classList.remove("navbar-light");
 	document.getElementsByClassName('navbar')[0].classList.add("navbar-dark");
-} else if (getDarkCookie() == 'none') {
-	let prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
-	setDarkCookie(prefersDarkMode);
 }
 		</script>
 	</body>


### PR DESCRIPTION
Alguns usuários tão reclamando do modo escuro "reativando"... Provavelmente estão usando o modo anônimo do navegador. Então acho que fica melhor tirar a ativação automática, até porque agora todos já sabem que a opção existe