### PR TITLE
Fix tradução do humanize

### DIFF
--- a/main_app/models.py
+++ b/main_app/models.py
@@ -175,6 +175,8 @@ class Notification(models.Model):
 			response = Response.objects.get(id=answer_id)
 			self.text = '<p>Sua resposta foi escolhida a melhor resposta da pergunta: <a href="/question/{}">"{}"</a></p>'.format(response.question.id, response.question.text)
 
+	def get_naturaltime(self):
+		return correct_naturaltime(naturaltime(self.creation_date))
 
 
 

--- a/main_app/templates/notification.html
+++ b/main_app/templates/notification.html
@@ -39,7 +39,7 @@
             	{% for notification in notifications %}
                 <li class="list-group-item bg-main">
 	                <div class="card-body">
-	                    <p class="ntime">{{ notification.creation_date|naturaltime }}</p>
+	                    <p title="{{ notification.creation_date }}" class="ntime">{{ notification.get_naturaltime }}</p>
 	                    <p class="ntext">{{ notification.text|safe }}</p>
                     </div>
                 </li>


### PR DESCRIPTION
Arrumei a falta de espaço (bug do humanize) "6dias, 1horaatrás" pra "6 dias, 1 hora atrás".
Também coloquei o tempo exato com hover na data, assim como tá nas perguntas/respostas