### PR TITLE
Tentativa de fix

### DIFF
--- a/main_app/templates/index.html
+++ b/main_app/templates/index.html
@@ -8,13 +8,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="description" content="Faça e responda perguntas na melhor e mais divertida comunidade de perguntas e respostas!">
 		<meta name="keywords" content="br.asker.fun, asker.fun, perguntas, respostas, asker">
-
-		<style id="wait">
-			body {
-				visibility: hidden;
-				opacity: 0;
-			}
-		</style>
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css">
 		<link rel="stylesheet" href="/static/css/common.css?v=7">
 		<script src="/static/js/cookieman.js?v=1"></script>
@@ -27,8 +20,6 @@
 			link.type = 'text/css';
 			link.href = '/static/css/' + cssfn + cssversion;
 			document.head.appendChild(link);
-
-			document.getElementById('wait').remove();
 		</script>
 
 		<script data-ad-client="ca-pub-4483250714447468" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>


### PR DESCRIPTION
Como até hoje não consegui replicar o bug dessa gente que não ve os sections do index.html, pensei em, como uma medida de desespero, tirar o style.wait da index.html

Esse style deixava a página invisível até o css das cores do tema ser carregado, pra impedir o white flash of death.

Acho muito improvável, mas pode ser que estivesse conflitando com os *-questions.html...

Se não for o caso, seria interessante colocar a função de volta no futuro, pois o white flash obviamente irrita muito quem usa o modo escuro.