### PR TITLE
Tam. max de avatar

### DIFF
--- a/main_app/templates/base/response-content.html
+++ b/main_app/templates/base/response-content.html
@@ -5,7 +5,7 @@
 		<div class="poster-container">
 			<a class="poster-info" href="/user/{{ response.creator.user.username }}">
 				<div class="poster-profile-pic-container">
-					<img width="40px" src="{{ response.creator.avatar.url }}" alt="{{ response.creator.user.username }}">
+					<img src="{{ response.creator.avatar.url }}" alt="{{ response.creator.user.username }}">
 				</div>
 				
 				<div class="poster-text-container">

--- a/main_app/templates/question.html
+++ b/main_app/templates/question.html
@@ -13,7 +13,7 @@
 		</style>
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.1.3/dist/css/bootstrap.min.css">
 		<script src="/static/js/cookieman.js?v=1"></script>
-		<link rel="stylesheet" href="/static/css/common.css?v=8.1">
+		<link rel="stylesheet" href="/static/css/common.css?v=8.1.1">
 		<script>
 			var cssfn = 'light.css';
 			var cssversion = '?v=5';
@@ -45,7 +45,7 @@
 					<div class="poster-container">
 						<a class="poster-info" href="/user/{{ question.creator.user.username }}">
 							<div class="poster-profile-pic-container">
-								<img title="{{ question.creator.user.username }}" class="poster-profile-pic-popover" width="45px" src="{{ question.creator.avatar.url }}" alt="{{ question.creator.user.username }}">
+								<img title="{{ question.creator.user.username }}" class="poster-profile-pic-popover" src="{{ question.creator.avatar.url }}" alt="{{ question.creator.user.username }}">
 							</div>
 							<div class="poster-text-container">
 								<div>

--- a/main_app/templatetags/main_app_extras.py
+++ b/main_app/templatetags/main_app_extras.py
@@ -36,7 +36,7 @@ def list_comments(response_id, request):
 						<div class="poster-container">
 								<a class="poster-info" href="/user/{}">
 										<div class="poster-profile-pic-container">
-												<img src="{}" width="40px">
+												<img src="{}">
 										</div>
 										<div class="poster-text-container">
 												<span>{}</span>
@@ -56,7 +56,7 @@ def list_comments(response_id, request):
 						<div class="poster-container">
 								<a class="poster-info" href="/user/{}">
 										<div class="poster-profile-pic-container">
-												<img src="{}" width="40px">
+												<img src="{}">
 										</div>
 										<div class="poster-text-container">
 												<span>{}</span>

--- a/main_app/views.py
+++ b/main_app/views.py
@@ -584,7 +584,7 @@ def comment(request):
 						<div class="poster-container">
 								<a class="poster-info" href="/user/{}">
 										<div class="poster-profile-pic-container">
-												<img src="{}" width="40px">
+												<img src="{}">
 										</div>
 										<div class="poster-text-container">
 												<span>{}</span>

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -139,6 +139,12 @@ textarea.large-compact {
   align-items: center;
   padding-right: 6px;
 }
+.poster-profile-pic-container img {
+  min-width: 45px;
+  min-height: 20px;
+  max-width: 70px;
+  max-height: 70px;
+}
 
 .poster-text-container .r-username {
 	display: block;


### PR DESCRIPTION
Não sei como nenhum engraçadinho ainda encontrou o exploit, mas se vc colocar uma imagem proporcionalmente alta, a página quebra toda, já que por enquanto só tem restraint de largura pro tamanho máximo de avatar. Alguns users já estão usando imagens enormes, mas felizmente não chegaram a destruir as páginas como se usassem por exemplo um avatar 50x1000.